### PR TITLE
Remove extra whitespace in project/plugins.sbt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.5")
-


### PR DESCRIPTION
This was a small issue that I saw, so I thought I'd take the 3s it did to fix it.

It removes a single line of whitespace that is not necessary.

@thomas-stripe