### PR TITLE
Execute function during `sbt run` in Main.scala

### DIFF
--- a/src/main/scala/com/example/Main.scala
+++ b/src/main/scala/com/example/Main.scala
@@ -3,7 +3,7 @@ package com.example
 object Main extends App {
   def excite(s: String): String = s"$s!"
 
-  def main(): Unit = {
+  override def main(): Unit = {
     println(excite("Hello, world"))
   }
 }

--- a/src/main/scala/com/example/Main.scala
+++ b/src/main/scala/com/example/Main.scala
@@ -3,7 +3,5 @@ package com.example
 object Main extends App {
   def excite(s: String): String = s"$s!"
 
-  override def main(): Unit = {
-    println(excite("Hello, world"))
-  }
+  println(excite("Hello, world"))
 }


### PR DESCRIPTION
When running this from sbt, it doesn't actually run the code in `def main()`; you can do two things here, according to https://www.scala-lang.org/api/current/scala/App.html:

1) you can just put the code in the body of the class, and that "becomes" the main method.
2) You can `override` `def main`, and that'll also get it to run. 

However, https://www.scala-lang.org/api/current/scala/App.html says:
> It should also be noted that the main method should not be overridden: the whole class body becomes the “main method”.

So I went with (1)!

Thought I'd open up a PR and save a future interviewee a few min of panic when `sbt run` doesn't output what I thought it would :)